### PR TITLE
direnv: fix op inject parsing errors in templates

### DIFF
--- a/direnv/.config/direnv/direnvrc
+++ b/direnv/.config/direnv/direnvrc
@@ -27,5 +27,5 @@ op_inject() {
     echo "direnv: op inject failed — check 'op signin --account $account'" >&2
     return 1
   }
-  echo "$injected" | dotenv /dev/stdin
+  eval "$injected"
 }

--- a/direnv/.config/direnv/templates/personal.env.tpl
+++ b/direnv/.config/direnv/templates/personal.env.tpl
@@ -1,10 +1,4 @@
 # Personal 1Password secret template
-# Uncomment and populate with your op:// references.
-# Format: export KEY={{ op://VaultName/ItemName/field }}
-#
-# Examples:
-# export GITHUB_TOKEN={{ op://Personal/GitHub Token/token }}
-# export AWS_ACCESS_KEY_ID={{ op://Personal/AWS Personal/access_key_id }}
-# export AWS_SECRET_ACCESS_KEY={{ op://Personal/AWS Personal/secret_access_key }}
+# Add secrets below. See direnvrc for usage.
 export GITHUB_PERSONAL_ACCESS_TOKEN={{ op://Personal/GitHub MCP PAT/credential }}
 export GITHUB_MCP_PAT={{ op://Personal/GitHub MCP PAT/credential }}

--- a/direnv/.config/direnv/templates/work.env.tpl
+++ b/direnv/.config/direnv/templates/work.env.tpl
@@ -1,8 +1,2 @@
 # Work 1Password secret template
-# Uncomment and populate with your op:// references.
-# Format: export KEY={{ op://VaultName/ItemName/field }}
-#
-# Examples:
-# export GITHUB_TOKEN={{ op://Work/GitHub Token/token }}
-# export AWS_ACCESS_KEY_ID={{ op://Work/AWS Work/access_key_id }}
-# export AWS_SECRET_ACCESS_KEY={{ op://Work/AWS Work/secret_access_key }}
+# Add secrets below. See direnvrc for usage.


### PR DESCRIPTION
## Summary
- Remove `op://` and `{{ }}` patterns from template comment lines that `op inject` was incorrectly parsing as secret references
- Replace `dotenv /dev/stdin` with `eval` in direnvrc since `op inject` outputs `export KEY=value` lines

## Test plan
- [x] `stow -D direnv && stow direnv` completes without errors
- [x] `direnv` loads `~/.envrc` successfully and injects secrets from 1Password

🤖 Generated with [Claude Code](https://claude.com/claude-code)